### PR TITLE
fix content title font

### DIFF
--- a/sass/headers/mixins.scss
+++ b/sass/headers/mixins.scss
@@ -23,6 +23,8 @@
   margin-bottom: 50px;
 
   &__title {
+    font-family: "times new roman", times, serif;
+    font-style: italic;
     font-size: 28px;
     font-weight: normal;
     display: inline-block;


### PR DESCRIPTION
> 4.各項目のタイトル部分を、Minion Pro Medium Italicにできますでしょうか？それに合わせてヘッダー部分もご調整願います。

正直、どっからどこまでが修正対象なのかよく分かっていません...。
現状は、トップページの"Pick Up"、"Salvage Report"、"Interview & Column"、"Instagram" と、それらの項目の詳細個別ページのヘッダータイトル部分に Times new roman を指定してます。